### PR TITLE
feat(toJSON): add optional iterator parameter for plain JSON output

### DIFF
--- a/.changeset/bright-waves-dance.md
+++ b/.changeset/bright-waves-dance.md
@@ -1,0 +1,5 @@
+---
+"xult": minor
+---
+
+feat(toJSON): add optional iterator parameter to control Symbol.iterator inclusion

--- a/src/result.ts
+++ b/src/result.ts
@@ -1176,7 +1176,7 @@ export class Result<TValue, TError extends Result.LooseErrorShape> {
 	 * ```
 	 */
 	// note: does not extend `Result.Any` due to circulary errors with fromJSON
-	toJSON<TThis>(this: TThis): Result.JSON<Result.ValueOf<TThis>, Result.ErrorOf<TThis>>
+	toJSON<TThis, TIterator extends boolean = true>(this: TThis, iterator?: TIterator): TIterator extends false ? Result.PlainJSON<Result.ValueOf<TThis>, Result.ErrorOf<TThis>> : Result.JSON<Result.ValueOf<TThis>, Result.ErrorOf<TThis>>
 	{
 		const self = this as Result.Any
 		const obj = { ok: self instanceof Ok } as {
@@ -1196,6 +1196,8 @@ export class Result<TValue, TError extends Result.LooseErrorShape> {
 			obj.details = self.details
 			obj.stack = self.stack
 		}
+
+		if(iterator === false) return obj as any
 
 		obj[Symbol.iterator] = function*() {
 			yield this
@@ -1599,11 +1601,12 @@ export namespace Result {
 	export type AnyOk = Ok<any, never>
 	export type AnyErr = Err<never, any>
 
+	export type PlainJSON<TValue = unknown, TError extends LooseErrorShape = ErrorShape> = 
+		| ([TValue] extends [never] ? never : { ok: true, value: TValue })
+		| ([TError] extends [never] ? never : { ok: false, code: TError['code'], message: string, stack?: string } & ('details' extends keyof TError ? TError['details'] extends undefined ? {} : { details: TError['details'] } : {}))
+
 	export type JSON<TValue = unknown, TError extends LooseErrorShape = ErrorShape> = { [Result.symbol]: true } & (
-		(
-			| ([TValue] extends [never] ? never : { ok: true, value: TValue })
-			| ([TError] extends [never] ? never : TError & { ok: false, stack?: string, message: string } & (TError extends { message: any } ? {} : { message: string }))
-		) extends infer X ? X & {
+		PlainJSON<TValue, TError> extends infer X ? X & {
 			[Symbol.iterator]: () => Generator<X, TValue, unknown>
 		} : never
 	)

--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -389,3 +389,103 @@ describe('[type] Serialization type inference', () => {
 		}
 	})
 })
+
+describe('toJSON - iterator parameter', () => {
+	test('toJSON() returns Result.JSON with iterator by default', () => {
+		const r = ok({ name: 'Alice' })
+		const json = r.toJSON()
+
+		expect(json.ok).toBe(true)
+		expect(json.value).toEqual({ name: 'Alice' })
+		expect(typeof json[Symbol.iterator]).toBe('function')
+
+		// type tests
+		expectTypeOf(json).toEqualTypeOf<Result.JSON<{ name: string }, never>>()
+		expectTypeOf(json).toMatchTypeOf<{ ok: true, value: { name: string } }>()
+	})
+
+	test('toJSON(true) returns Result.JSON with iterator', () => {
+		const r = ok(42)
+		const json = r.toJSON(true)
+
+		expect(json.ok).toBe(true)
+		expect(json.value).toBe(42)
+		expect(typeof json[Symbol.iterator]).toBe('function')
+
+		expect(Object.getOwnPropertySymbols(json)).toHaveLength(1)
+
+		// type tests
+		expectTypeOf(json).toEqualTypeOf<Result.JSON<number, never>>()
+	})
+
+	test('toJSON(false) returns Result.PlainJSON without iterator', () => {
+		const r = ok({ id: 123 })
+		const json = r.toJSON(false)
+
+		expect(json.ok).toBe(true)
+		expect(json.value).toEqual({ id: 123 })
+		expect((json as any)[Symbol.iterator]).toBeUndefined()
+
+		expect(Object.getOwnPropertySymbols(json)).toHaveLength(0)
+
+		// type tests
+		expectTypeOf(json).toEqualTypeOf<Result.PlainJSON<{ id: number }, never>>()
+		expectTypeOf(json).toMatchTypeOf<{ ok: true, value: { id: number } }>()
+	})
+
+	test('toJSON(false) on Err returns plain error object', () => {
+		const r = err('NOT_FOUND', 'User not found', { userId: 'abc' })
+		const json = r.toJSON(false)
+
+		expect(json.ok).toBe(false)
+		expect(json.code).toBe('NOT_FOUND')
+		expect(json.message).toBe('User not found')
+		expect(json.details).toEqual({ userId: 'abc' })
+		expect(json.stack).toBeString()
+		expect((json as any)[Symbol.iterator]).toBeUndefined()
+
+		// type tests
+		expectTypeOf(json).toEqualTypeOf<Result.PlainJSON<never, { code: 'NOT_FOUND', details: { userId: string } }>>()
+	})
+
+	test('PlainJSON type is a clean union type', () => {
+		const okResult = ok('success')
+		const errResult = err('FAIL', 'failed')
+
+		const okJson = okResult.toJSON(false)
+		const errJson = errResult.toJSON(false)
+
+		// Ok case: should be exactly { ok: true, value: string }
+		expectTypeOf(okJson).toEqualTypeOf<{ ok: true, value: string }>()
+
+		// Err case: should be { ok: false, code: 'FAIL', message: string, stack?: string }
+		expectTypeOf(errJson).toMatchTypeOf<{ ok: false, code: 'FAIL', message: string }>()
+	})
+
+	test('JSON type includes Symbol.iterator and Result.symbol', () => {
+		const r = ok(123)
+		const json = r.toJSON(true)
+
+		// Should have Symbol.iterator
+		expectTypeOf(json[Symbol.iterator]).toBeFunction()
+		expectTypeOf(json[Symbol.iterator]).returns.toMatchTypeOf<Generator<any, number, unknown>>()
+
+		// Should have Result.symbol key
+		expectTypeOf(json[Result.symbol]).toEqualTypeOf<true>()
+	})
+
+	test('iterator on Result.JSON works correctly', () => {
+		const r = ok({ count: 5 })
+		const json = r.toJSON()
+
+		const iterator = json[Symbol.iterator]()
+		const first = iterator.next()
+
+		expect(first.done).toBe(false)
+		expect(first.value).toBe(json)
+
+		const second = iterator.next()
+		expect(second.done).toBe(true)
+		expect(second.value).toEqual({ count: 5 })
+	})
+})


### PR DESCRIPTION
## Summary

This PR enhances the `toJSON()` method with an optional `iterator` parameter that controls whether `Symbol.iterator` is included in the serialized output.

## Changes

### `src/result.ts`
- **Enhanced `toJSON()` signature**: Added optional generic parameter `TIterator extends boolean = true` to control iterator inclusion
- **New `Result.PlainJSON` type**: A clean JSON type without `Symbol.iterator` or `Result.symbol`, useful for serialization to external systems
- **Conditional return type**: `toJSON(false)` returns `Result.PlainJSON`, `toJSON()` or `toJSON(true)` returns `Result.JSON` (with iterator)
- **Refactored `Result.JSON` type**: Now extends `PlainJSON` to avoid code duplication

### `tests/serialization.test.ts`
- Added comprehensive tests for the new `iterator` parameter
- Tests cover both `Ok` and `Err` results with `toJSON(false)`
- Type tests verify correct type inference for `Result.JSON` vs `Result.PlainJSON`
- Tests verify `Symbol.iterator` presence/absence based on parameter

## Use Case

When serializing Results for transport (e.g., HTTP responses, message queues), you often want plain JSON without symbols:

```typescript
// Before: Had to manually strip symbols or work around it
const response = result.toJSON()
delete response[Symbol.iterator]

// After: Clean and type-safe
const response = result.toJSON(false)
// => { ok: true, value: ... } or { ok: false, code: ..., message: ... }
```

## Breaking Changes

None. The default behavior (`toJSON()`) remains unchanged and returns `Result.JSON` with the iterator included.